### PR TITLE
Fully remove GPU ID override

### DIFF
--- a/arch/arm/boot/dts/qcom/sdm636.dtsi
+++ b/arch/arm/boot/dts/qcom/sdm636.dtsi
@@ -72,9 +72,3 @@
 		/delete-node/ qcom,msm_fastrpc_compute_cb13;
 	};
 };
-
-/* GPU overrides */
-&msm_gpu {
-		/* Update GPU chip ID*/
-		qcom,chipid = <0x05000900>;
-};

--- a/arch/arm/boot/dts/qcom/sdm636_e7t.dtsi
+++ b/arch/arm/boot/dts/qcom/sdm636_e7t.dtsi
@@ -73,9 +73,3 @@
 		/delete-node/ qcom,msm_fastrpc_compute_cb13;
 	};
 };
-
-/* GPU overrides */
-&msm_gpu {
-		/* Update GPU chip ID*/
-		qcom,chipid = <0x05000900>;
-};


### PR DESCRIPTION
Some games requied Adreno 512 for HD quality, this commit FULLY removed override to 509